### PR TITLE
Add Yahoo fallback for GLD price ingestion

### DIFF
--- a/scripts/update.py
+++ b/scripts/update.py
@@ -27,6 +27,7 @@ FRED_SERIES = {
     "be10": "T10YIE",
 }
 GLD_STOOQ_URL = "https://stooq.com/q/d/l/?s=gld.us&i=d"
+GLD_YAHOO_CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart/GLD?interval=1d&range=10y"
 GLD_HOLDINGS_URL = "https://www.spdrgoldshares.com/assets/dynamic/GLD/GLD_US_archive_EN.csv"
 GLD_HOLDINGS_ARCHIVE_URL = "https://api.spdrgoldshares.com/api/v1/historical-archive?product=gld&exchange=NYSE&lang=en"
 TRADING_DAYS_1M = 21
@@ -94,8 +95,54 @@ def parse_stooq_csv(csv_text: str) -> List[Tuple[datetime, Decimal]]:
 
 
 def fetch_gld_prices() -> List[Tuple[datetime, Decimal]]:
-    csv_text = fetch_url(GLD_STOOQ_URL)
-    return parse_stooq_csv(csv_text)
+    errors: List[str] = []
+
+    try:
+        csv_text = fetch_url(GLD_STOOQ_URL)
+        rows = parse_stooq_csv(csv_text)
+        if rows:
+            return rows
+        errors.append("stooq returned empty dataset")
+    except Exception as exc:
+        errors.append(f"stooq fetch failed: {exc}")
+
+    try:
+        payload = fetch_url(GLD_YAHOO_CHART_URL)
+        rows = parse_yahoo_chart_json(payload)
+        if rows:
+            return rows
+        errors.append("yahoo returned empty dataset")
+    except Exception as exc:
+        errors.append(f"yahoo fetch failed: {exc}")
+
+    raise DataFetchError("No GLD price data available; " + "; ".join(errors))
+
+
+def parse_yahoo_chart_json(payload: str) -> List[Tuple[datetime, Decimal]]:
+    parsed = json.loads(payload)
+    chart = parsed.get("chart", {})
+    error = chart.get("error")
+    if error:
+        raise DataFetchError(f"Yahoo chart API error: {error}")
+
+    results = chart.get("result") or []
+    if not results:
+        return []
+    series = results[0]
+    timestamps = series.get("timestamp") or []
+    quote = ((series.get("indicators") or {}).get("quote") or [{}])[0]
+    closes = quote.get("close") or []
+
+    rows: List[Tuple[datetime, Decimal]] = []
+    for ts, close in zip(timestamps, closes):
+        if close is None:
+            continue
+        try:
+            rows.append((datetime.fromtimestamp(int(ts), tz=timezone.utc).replace(tzinfo=None), Decimal(str(close))))
+        except Exception:
+            continue
+    rows.sort(key=lambda item: item[0])
+    return rows
 
 
 def parse_holdings_csv(csv_text: str) -> List[Tuple[datetime, Decimal]]:

--- a/scripts/workflow_status.py
+++ b/scripts/workflow_status.py
@@ -7,6 +7,14 @@ import os
 from pathlib import Path
 
 
+def write_env_var(handle, key: str, value: str) -> None:
+    if "\n" in value:
+        delimiter = "__GOLD_RISK_MONITOR__"
+        handle.write(f"{key}<<{delimiter}\n{value}\n{delimiter}\n")
+        return
+    handle.write(f"{key}={value}\n")
+
+
 def main() -> int:
     status_path = Path("/tmp/monitor_status.json")
     status = json.loads(status_path.read_text())
@@ -22,11 +30,11 @@ def main() -> int:
 
     env_path = Path(env_file)
     with env_path.open("a", encoding="utf-8") as handle:
-        handle.write(f"FETCH_OK={fetch_ok}\n")
-        handle.write(f"FLAG={flag}\n")
-        handle.write(f"ISSUE_NEEDED={issue_needed}\n")
-        handle.write(f"ISSUE_TITLE={issue_title}\n")
-        handle.write(f"ISSUE_BODY={issue_body}\n")
+        write_env_var(handle, "FETCH_OK", fetch_ok)
+        write_env_var(handle, "FLAG", flag)
+        write_env_var(handle, "ISSUE_NEEDED", issue_needed)
+        write_env_var(handle, "ISSUE_TITLE", issue_title)
+        write_env_var(handle, "ISSUE_BODY", issue_body)
     return 0
 
 


### PR DESCRIPTION
### Motivation
- Stooq now sometimes returns an API-key instruction page instead of the historical CSV, causing `fetch_gld_prices()` to yield no rows and the workflow to fail with `No GLD price data available`.
- Ensure the Gold Risk Monitor can still obtain GLD prices so data updates and downstream alerts remain functional.

### Description
- Added `GLD_YAHOO_CHART_URL` and a Yahoo Finance chart fallback in `scripts/update.py` to provide an alternate source for GLD daily prices.
- Reworked `fetch_gld_prices()` to try Stooq first and then Yahoo, and to aggregate source-specific failure reasons before raising `DataFetchError` when both providers fail.
- Implemented `parse_yahoo_chart_json()` which converts Yahoo chart JSON `timestamp`/`close` arrays into the existing `(datetime, Decimal)` row format used by the pipeline.

### Testing
- Ran a direct fetch using `from scripts.update import fetch_gld_prices` which returned `2515` rows and a recent final row `(datetime.datetime(2026, 4, 10, 13, 30), Decimal('437.1300048828125'))` indicating successful ingestion from a fallback source.
- Verified syntax by running `python -m py_compile scripts/update.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da417306fc832ab633df8d2c4a7650)